### PR TITLE
aws-amplify is a required dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "aws-amplify":"^0.3.3",
     "esri-loader": "^2.2.0",
     "normalize.css": "^8.0.0",
     "react": "^16.2.0",


### PR DESCRIPTION
can't yarn start without it

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
