### PR TITLE
-n argument only works with device farm enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ const isAuthenticated = () => Amplify.Auth.user !== null;
 Run the following to publish the new site:
 
 ```
-awsmobile publish -c -n -f
+awsmobile publish -c -f
 ```
 
 This will ensure CloudFront is also flushed.  If in doubt, go to the S3 bucket instead.  You should now be able to click on the Ride! button and get a sign-up / sign-in button.  When signed-in, you should see the temporary Ride page.


### PR DESCRIPTION
error: unknown option `-n'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
