### PR TITLE
Rename `error` to `err` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ import { Analytics } from 'aws-amplify'
 
 // track error in the signUp method
 .catch(err => {
-  Analytics.record('Error signing up!', { message: error.message })
+  Analytics.record('Error signing up!', { message: err.message })
   console.log('error signing up: ', err)
 })
 ```


### PR DESCRIPTION
Renamed `error` to `err` as `error` is undefined

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
